### PR TITLE
Add utility to transform GAS iterators into native ES6 iterable

### DIFF
--- a/utils/es6Iterator.js
+++ b/utils/es6Iterator.js
@@ -1,0 +1,21 @@
+/**
+ * Transforms a Google Apps Script iterator into an ECMAScript 6 iterator.
+ * This allows the user to iterate using `for ... of`. Example:
+ * ```
+ * for (let file of it(folder.getFiles())) {
+ *  // use file
+ * }
+ * ```
+ *
+ * @param gasIt The Google Apps Script iterator
+ * @returns A native ES6 iterable
+ */
+function it(gasIt) {
+    return {
+        *[Symbol.iterator]() {
+            while (gasIt.hasNext()) {
+                yield gasIt.next()
+            }
+        }
+    }
+}


### PR DESCRIPTION
 This allows the user to iterate using `for ... of`. Example:
 ```javascript
 for (let file of it(folder.getFiles())) {
  // use file
 }
 ```